### PR TITLE
update to rivet 2.5.3

### DIFF
--- a/MC_VHbb.h
+++ b/MC_VHbb.h
@@ -1,4 +1,4 @@
-#include "Rivet/Cuts.hh"
+#include "Rivet/Tools/Cuts.hh" 
 #include "Rivet/Analysis.hh"
 #include "Rivet/Projections/VetoedFinalState.hh"
 #include "Rivet/Projections/FinalState.hh"
@@ -17,7 +17,7 @@ namespace Rivet {
   //////////////////////////////////////////////////
 
   using namespace Cuts;
-  Cut cut = etaIn(-5,5) & (pT >= 0.0*GeV);
+  Cut cut = etaIn(-5,5) & (Cuts::pT >= 0.0*GeV);
 
   static const size_t NJet_bins = 4;
   
@@ -30,8 +30,8 @@ namespace Rivet {
   
   string ptbin_labels[Vpt_bins]             =   {  "Incl",  "Low",  "Med",   "High"};
   
-  double cut_Zll_pt_low_edge_bin[Vpt_bins]  =   {   0*GeV,  0*GeV,100*GeV, 200*GeV};
-  double cut_Zll_pt_high_edge_bin[Vpt_bins] =   {1e10*GeV,100*GeV,200*GeV,1e10*GeV};
+  double cut_Zll_pt_low_edge_bin[Vpt_bins]  =   {   0*GeV,  0*GeV,150*GeV, 250*GeV};
+  double cut_Zll_pt_high_edge_bin[Vpt_bins] =   {1e10*GeV,150*GeV,250*GeV,1e10*GeV};
 
   double cut_Znunu_pt_low_edge_bin[Vpt_bins]  = {   0*GeV,  0*GeV,150*GeV, 250*GeV};
   double cut_Znunu_pt_high_edge_bin[Vpt_bins] = {1e10*GeV,150*GeV,250*GeV,1e10*GeV};

--- a/MC_WlnuHbb_decayed.cc
+++ b/MC_WlnuHbb_decayed.cc
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -*- C++ -*- 
 #include "MC_VHbb.h"
 
 namespace Rivet {
@@ -49,7 +49,9 @@ namespace Rivet {
       ////////////////////////////////////////////////////////
       // Unstable Higgs
       ////////////////////////////////////////////////////////
-      UnstableFinalState undec_higgs(PID::HIGGS);
+      Cut cut_pid_higgs = (Cuts::pid==PID::HIGGS);
+      UnstableFinalState undec_higgs(cut_pid_higgs);
+      //UnstableFinalState undec_higgs(PID::HIGGS);
       addProjection(undec_higgs, "UFS");
       IdentifiedFinalState higgses(PID::HIGGS);
       jetproinput.addVetoOnThisFinalState(higgses);
@@ -307,7 +309,8 @@ namespace Rivet {
       // Jet resolutions and integrated jet rates
       double d_ij;
       const FastJets& jetpro_kt = applyProjection<FastJets>(event,"jetpro_kt");
-      const fastjet::ClusterSequence* seq = jetpro_kt.clusterSeq();
+      //const fastjet::ClusterSequence* seq = jetpro_kt.clusterSeq();
+      const shared_ptr<fastjet::ClusterSequence> seq = jetpro_kt.clusterSeq();
       if (seq != NULL) {
         for (size_t i = 0; i < njets; ++i) {
           // Jet resolution i -> j

--- a/MC_WlnuHbb_undecayed.cc
+++ b/MC_WlnuHbb_undecayed.cc
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -*- C++ -*- 
 #include "MC_VHbb.h"
 
 namespace Rivet {
@@ -49,7 +49,9 @@ namespace Rivet {
       ////////////////////////////////////////////////////////
       // Unstable Higgs
       ////////////////////////////////////////////////////////
-      UnstableFinalState undec_higgs(PID::HIGGS);
+      Cut cut_pid_higgs = (Cuts::pid==PID::HIGGS);
+      UnstableFinalState undec_higgs(cut_pid_higgs);
+      //UnstableFinalState undec_higgs(PID::HIGGS);
       addProjection(undec_higgs, "UFS");
       IdentifiedFinalState higgses(PID::HIGGS);
       jetproinput.addVetoOnThisFinalState(higgses);
@@ -283,7 +285,8 @@ namespace Rivet {
       // Jet resolutions and integrated jet rates
       double d_ij;
       const FastJets& jetpro_kt = applyProjection<FastJets>(event,"jetpro_kt");
-      const fastjet::ClusterSequence* seq = jetpro_kt.clusterSeq();
+      //const fastjet::ClusterSequence* seq = jetpro_kt.clusterSeq();
+      const shared_ptr<fastjet::ClusterSequence> seq = jetpro_kt.clusterSeq();
       if (seq != NULL) {
         for (size_t i = 0; i < njets; ++i) {
           // Jet resolution i -> j

--- a/MC_ZllHbb_decayed.cc
+++ b/MC_ZllHbb_decayed.cc
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -*- C++ -*- 
 #include "MC_VHbb.h"
 
 namespace Rivet {
@@ -49,7 +49,9 @@ namespace Rivet {
       ////////////////////////////////////////////////////////
       // Unstable Higgs
       ////////////////////////////////////////////////////////
-      UnstableFinalState undec_higgs(PID::HIGGS);
+      Cut cut_pid_higgs = (Cuts::pid==PID::HIGGS);
+      UnstableFinalState undec_higgs(cut_pid_higgs);
+      //UnstableFinalState undec_higgs(PID::HIGGS);
       addProjection(undec_higgs, "UFS");
       IdentifiedFinalState higgses(PID::HIGGS);
       jetproinput.addVetoOnThisFinalState(higgses);
@@ -312,7 +314,8 @@ namespace Rivet {
       // Jet resolutions and integrated jet rates
       double d_ij;
       const FastJets& jetpro_kt = applyProjection<FastJets>(event,"jetpro_kt");
-      const fastjet::ClusterSequence* seq = jetpro_kt.clusterSeq();
+      //const fastjet::ClusterSequence* seq = jetpro_kt.clusterSeq();
+      const shared_ptr<fastjet::ClusterSequence> seq = jetpro_kt.clusterSeq();
       if (seq != NULL) {
         for (size_t i = 0; i < njets; ++i) {
           // Jet resolution i -> j

--- a/MC_ZllHbb_undecayed.cc
+++ b/MC_ZllHbb_undecayed.cc
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -*- C++ -*- 
 #include "MC_VHbb.h"
 
 namespace Rivet {
@@ -49,7 +49,9 @@ namespace Rivet {
       ////////////////////////////////////////////////////////
       // Unstable Higgs
       ////////////////////////////////////////////////////////
-      UnstableFinalState undec_higgs(PID::HIGGS);
+      Cut cut_pid_higgs = (Cuts::pid==PID::HIGGS);
+      UnstableFinalState undec_higgs(cut_pid_higgs);
+      //UnstableFinalState undec_higgs(PID::HIGGS);
       addProjection(undec_higgs, "UFS");
       IdentifiedFinalState higgses(PID::HIGGS);
       jetproinput.addVetoOnThisFinalState(higgses);
@@ -278,7 +280,8 @@ namespace Rivet {
       // Jet resolutions and integrated jet rates
       double d_ij;
       const FastJets& jetpro_kt = applyProjection<FastJets>(event,"jetpro_kt");
-      const fastjet::ClusterSequence* seq = jetpro_kt.clusterSeq();
+      const shared_ptr<fastjet::ClusterSequence> seq = jetpro_kt.clusterSeq();
+      //const fastjet::ClusterSequence* seq = jetpro_kt.clusterSeq();
       if (seq != NULL) {
         for (size_t i = 0; i < njets; ++i) {
           // Jet resolution i -> j

--- a/MC_ZnunuHbb_decayed.cc
+++ b/MC_ZnunuHbb_decayed.cc
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -*- C++ -*- 
 #include "MC_VHbb.h"
 
 namespace Rivet {
@@ -53,7 +53,9 @@ namespace Rivet {
       ////////////////////////////////////////////////////////
       // Unstable Higgs
       ////////////////////////////////////////////////////////
-      UnstableFinalState undec_higgs(PID::HIGGS);
+      Cut cut_pid_higgs = (Cuts::pid==PID::HIGGS);
+      UnstableFinalState undec_higgs(cut_pid_higgs);
+      //UnstableFinalState undec_higgs(PID::HIGGS);
       addProjection(undec_higgs, "UFS");
       IdentifiedFinalState higgses(PID::HIGGS);
       jetproinput.addVetoOnThisFinalState(higgses);
@@ -307,7 +309,8 @@ namespace Rivet {
       // Jet resolutions and integrated jet rates
       double d_ij;
       const FastJets& jetpro_kt = applyProjection<FastJets>(event,"jetpro_kt");
-      const fastjet::ClusterSequence* seq = jetpro_kt.clusterSeq();
+      //const fastjet::ClusterSequence* seq = jetpro_kt.clusterSeq();
+      const shared_ptr<fastjet::ClusterSequence> seq = jetpro_kt.clusterSeq();
       if (seq != NULL) {
         for (size_t i = 0; i < njets; ++i) {
           // Jet resolution i -> j

--- a/MC_ZnunuHbb_undecayed.cc
+++ b/MC_ZnunuHbb_undecayed.cc
@@ -1,4 +1,4 @@
-// -*- C++ -*-
+// -*- C++ -*- 
 #include "MC_VHbb.h"
 
 namespace Rivet {
@@ -53,7 +53,9 @@ namespace Rivet {
       ////////////////////////////////////////////////////////
       // Unstable Higgs
       ////////////////////////////////////////////////////////
-      UnstableFinalState undec_higgs(PID::HIGGS);
+      Cut cut_pid_higgs = (Cuts::pid==PID::HIGGS);
+      UnstableFinalState undec_higgs(cut_pid_higgs);
+      //UnstableFinalState undec_higgs(PID::HIGGS);
       addProjection(undec_higgs, "UFS");
       IdentifiedFinalState higgses(PID::HIGGS);
       jetproinput.addVetoOnThisFinalState(higgses);
@@ -283,7 +285,8 @@ namespace Rivet {
       // Jet resolutions and integrated jet rates
       double d_ij;
       const FastJets& jetpro_kt = applyProjection<FastJets>(event,"jetpro_kt");
-      const fastjet::ClusterSequence* seq = jetpro_kt.clusterSeq();
+      //const fastjet::ClusterSequence* seq = jetpro_kt.clusterSeq();
+      const shared_ptr<fastjet::ClusterSequence> seq = jetpro_kt.clusterSeq();
       if (seq != NULL) {
         for (size_t i = 0; i < njets; ++i) {
           // Jet resolution i -> j


### PR DESCRIPTION
1. Small updates to make the Rivet analysis compatible with Rivet v2.5.3
2. Zll VpT bin boundaries changed to [0, 150, 250, inf] for consistency with Zvv and Wlv channels